### PR TITLE
update test_appendix_d

### DIFF
--- a/compliance_checker/cf/appendix_d.py
+++ b/compliance_checker/cf/appendix_d.py
@@ -73,7 +73,7 @@ dimless_vertical_coordinates_1_6 = {  # only for CF-1.6
         ocean_computed_standard_names,
     ),
     "ocean_sigma_z_coordinate": (
-        {"sigma", "eta", "depth", "depth_c", "nsigma", "zlev"},
+        {"sigma", "eta", "depth", "depth_c", "zlev"},
         ocean_computed_standard_names,
     ),
     "ocean_double_sigma_coordinate": (

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -1060,7 +1060,7 @@ class TestCF1_6(BaseTestCase):
         self.assertTrue(
             no_missing_terms(
                 "ocean_sigma_z_coordinate",
-                {"sigma", "eta", "depth", "depth_c", "nsigma", "zlev"},
+                {"sigma", "eta", "depth", "depth_c", "zlev"},
                 dimless_vertical_coordinates_1_6,
             )
         )


### PR DESCRIPTION
This related to [issue#958](https://github.com/ioos/compliance-checker/issues/958)

Removed "nsigma" from a vertical coordinate variable with standard_name = "ocean_sigma_z_coordinate"