### PR TITLE
Updated test_check_cell_boundaries

### DIFF
--- a/compliance_checker/cf/cf_1_7.py
+++ b/compliance_checker/cf/cf_1_7.py
@@ -243,7 +243,7 @@ class CF1_7Check(CF1_6Check):
             variable = ds.variables[variable_name]
             valid = True
             reasoning = []
-            
+
             # 7.1 Required 1/5:
             # The type of the bounds attribute is a string whose value is a single variable name.
             # The specified variable must exist in the file.
@@ -257,7 +257,7 @@ class CF1_7Check(CF1_6Check):
                 )
             else:
                 boundary_variable = ds.variables[boundary_variable_name]
-            
+
             # 7.1 Required 2/5:
             # The number of dimensions in the bounds variable should always be
             # the number of dimensions in the referring variable + 1
@@ -310,7 +310,7 @@ class CF1_7Check(CF1_6Check):
 
             # 7.1 Required 3/5:
             # A boundary variable must be a numeric data type
-            if boundary_variable.dtype.kind not in 'biufc':
+            if boundary_variable.dtype.kind not in "biufc":
                 valid = False
                 reasoning.append(
                     "Boundary variable {} specified by {}".format(
@@ -319,22 +319,26 @@ class CF1_7Check(CF1_6Check):
                     + "must be a numeric data type "
                 )
 
-            # 7.1 Required 4/5: 
-            # If a boundary variable has units, standard_name, axis, positive, calendar, leap_month, 
+            # 7.1 Required 4/5:
+            # If a boundary variable has units, standard_name, axis, positive, calendar, leap_month,
             # leap_year or month_lengths attributes, they must agree with those of its associated variable.
-            if (boundary_variable.__dict__.keys()):
+            if boundary_variable.__dict__.keys():
                 for item in boundary_variable.__dict__.keys():
                     if hasattr(variable, item):
-                        if getattr(variable, item) != getattr(boundary_variable, item):                         
+                        if getattr(variable, item) != getattr(boundary_variable, item):
                             valid = False
                             reasoning.append(
-                            "'{}' has attr '{}' with value '{}' that does not agree "
-                            "with its associated variable ('{}')'s attr value '{}'"
-                            "".format(boundary_variable_name, item, getattr(boundary_variable,item),
-                                variable.name, getattr(variable,item), 
+                                "'{}' has attr '{}' with value '{}' that does not agree "
+                                "with its associated variable ('{}')'s attr value '{}'"
+                                "".format(
+                                    boundary_variable_name,
+                                    item,
+                                    getattr(boundary_variable, item),
+                                    variable.name,
+                                    getattr(variable, item),
                                 )
                             )
-            
+
             # 7.1 Required 5/5:
             # check if formula_terms is present in the var; if so,
             # the bounds variable must also have a formula_terms attr
@@ -347,17 +351,25 @@ class CF1_7Check(CF1_6Check):
                         )
                     )
 
-           # 7.1 Recommendations 2/2
-           # Boundary variables should not have the _FillValue, missing_value, units, standard_name, axis, 
-           # positive, calendar, leap_month, leap_year or month_lengths attributes.
-            attributes_to_check = {'_FillValue', 'missing_value', 'units', 
-                                'standard_name', 'axis', 'positive', 
-                                'calendar', 'leap_month', 'leap_year',
-                                 'month_lengths'}
-            if (boundary_variable.__dict__.keys()):
+            # 7.1 Recommendations 2/2
+            # Boundary variables should not have the _FillValue, missing_value, units, standard_name, axis,
+            # positive, calendar, leap_month, leap_year or month_lengths attributes.
+            attributes_to_check = {
+                "_FillValue",
+                "missing_value",
+                "units",
+                "standard_name",
+                "axis",
+                "positive",
+                "calendar",
+                "leap_month",
+                "leap_year",
+                "month_lengths",
+            }
+            if boundary_variable.__dict__.keys():
                 lst1 = boundary_variable.__dict__.keys()
                 lst2 = attributes_to_check
-                unwanted_attributes = [value for value in lst1 if value in lst2]            
+                unwanted_attributes = [value for value in lst1 if value in lst2]
                 if unwanted_attributes:
                     valid = False
                     reasoning.append(
@@ -365,7 +377,7 @@ class CF1_7Check(CF1_6Check):
                             boundary_variable_name, unwanted_attributes
                         )
                     )
-            
+
             result = Result(
                 BaseCheck.MEDIUM, valid, self.section_titles["7.1"], reasoning
             )
@@ -373,42 +385,48 @@ class CF1_7Check(CF1_6Check):
         return ret_val
 
     def check_cell_boundaries_interval(self, ds):
-        '''
+        """
         7.1 Cell Boundaries
         Recommendations: (1/2)
-        The points specified by a coordinate or auxiliary coordinate variable 
-        should lie within, or on the boundary, of the cells specified by the 
+        The points specified by a coordinate or auxiliary coordinate variable
+        should lie within, or on the boundary, of the cells specified by the
         associated boundary variable.
-        '''
+        """
         ret_val = []
         reasoning = []
         for variable_name, boundary_variable_name in cfutil.get_cell_boundary_map(
-            ds).items():
+            ds
+        ).items():
             valid = True
-            
+
             variable = ds.variables[variable_name]
             boundary_variable = ds.variables[boundary_variable_name]
-            
+
             for ii in range(len(variable[:])):
                 if abs(boundary_variable[ii][1]) >= abs(boundary_variable[ii][0]):
-                    if not ((abs(variable[ii]) >= abs(boundary_variable[ii][0])) \
-                        and \
-                        (abs(variable[ii]) <= abs(boundary_variable[ii][1]))
-                           ):
+                    if not (
+                        (abs(variable[ii]) >= abs(boundary_variable[ii][0]))
+                        and (abs(variable[ii]) <= abs(boundary_variable[ii][1]))
+                    ):
                         valid = False
                         reasoning.append(
-                            "The points specified by the coordinate variable {} ({})" 
-                            " lie outside the boundary of the cell specified by the " 
+                            "The points specified by the coordinate variable {} ({})"
+                            " lie outside the boundary of the cell specified by the "
                             "associated boundary variable {} ({})".format(
-                             variable_name, variable[ii], boundary_variable_name, boundary_variable[ii]
+                                variable_name,
+                                variable[ii],
+                                boundary_variable_name,
+                                boundary_variable[ii],
                             )
                         )
 
-                result = Result(BaseCheck.MEDIUM, valid, self.section_titles["7.1"], reasoning)
+                result = Result(
+                    BaseCheck.MEDIUM, valid, self.section_titles["7.1"], reasoning
+                )
                 ret_val.append(result)
                 print(ret_val)
-            return ret_val    
-    
+            return ret_val
+
     def check_cell_measures(self, ds):
         """
         A method to over-ride the CF1_6Check method. In CF 1.7, it is specified

--- a/compliance_checker/cf/cf_1_7.py
+++ b/compliance_checker/cf/cf_1_7.py
@@ -372,6 +372,43 @@ class CF1_7Check(CF1_6Check):
             ret_val.append(result)
         return ret_val
 
+    def check_cell_boundaries_interval(self, ds):
+        '''
+        7.1 Cell Boundaries
+        Recommendations: (1/2)
+        The points specified by a coordinate or auxiliary coordinate variable 
+        should lie within, or on the boundary, of the cells specified by the 
+        associated boundary variable.
+        '''
+        ret_val = []
+        reasoning = []
+        for variable_name, boundary_variable_name in cfutil.get_cell_boundary_map(
+            ds).items():
+            valid = True
+            
+            variable = ds.variables[variable_name]
+            boundary_variable = ds.variables[boundary_variable_name]
+            
+            for ii in range(len(variable[:])):
+                if abs(boundary_variable[ii][1]) >= abs(boundary_variable[ii][0]):
+                    if not ((abs(variable[ii]) >= abs(boundary_variable[ii][0])) \
+                        and \
+                        (abs(variable[ii]) <= abs(boundary_variable[ii][1]))
+                           ):
+                        valid = False
+                        reasoning.append(
+                            "The points specified by the coordinate variable {} ({})" 
+                            " lie outside the boundary of the cell specified by the " 
+                            "associated boundary variable {} ({})".format(
+                             variable_name, variable[ii], boundary_variable_name, boundary_variable[ii]
+                            )
+                        )
+
+                result = Result(BaseCheck.MEDIUM, valid, self.section_titles["7.1"], reasoning)
+                ret_val.append(result)
+                print(ret_val)
+            return ret_val    
+    
     def check_cell_measures(self, ds):
         """
         A method to over-ride the CF1_6Check method. In CF 1.7, it is specified

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -1897,13 +1897,13 @@ class TestCF1_7(BaseTestCase):
             )
 
     def test_check_cell_boundaries_interval(self):
-        '''
+        """
         7.1 Cell Boundaries
         Recommendations: (1/2)
-        The points specified by a coordinate or auxiliary coordinate variable 
-        should lie within, or on the boundary, of the cells specified by the 
+        The points specified by a coordinate or auxiliary coordinate variable
+        should lie within, or on the boundary, of the cells specified by the
         associated boundary variable.
-        ''' 
+        """
 
         # create Cells on a longitude axis
         dataset = MockTimeSeries()
@@ -1911,23 +1911,23 @@ class TestCF1_7(BaseTestCase):
         dataset.createDimension("rlon", 2)
         dataset.createVariable("rlon", "d", ("rlon",))
         dataset.createVariable("rlon_bnds", "d", ("rlon", "rnv"))
-        
+
         rlon = dataset.variables["rlon"]
-        rlon.standard_name = 'longitude'
-        rlon.units = 'degrees_east'
-        rlon.axis = 'X'  
-        rlon.long_name = 'Longitude'
-        rlon.bounds = 'rlon_bnds'
+        rlon.standard_name = "longitude"
+        rlon.units = "degrees_east"
+        rlon.axis = "X"
+        rlon.long_name = "Longitude"
+        rlon.bounds = "rlon_bnds"
         rlon[:] = np.array([-97.5, -99.5], dtype=np.float64)
 
         rlon_bnds = dataset.variables["rlon_bnds"]
-        rlon_bnds.long_name = 'Longitude Cell Boundaries'
-        rlon_bnds[:] = np.array([[-97, -98], [-98, -99]], dtype=np.float64)   
+        rlon_bnds.long_name = "Longitude Cell Boundaries"
+        rlon_bnds[:] = np.array([[-97, -98], [-98, -99]], dtype=np.float64)
 
         results = self.cf.check_cell_boundaries_interval(dataset)
         score, out_of, messages = get_results(results)
-        assert (score, out_of) == (1, 2)             
-                      
+        assert (score, out_of) == (1, 2)
+
     def test_cell_measures(self):
         """Over-ride the test_cell_measures from CF1_6"""
 

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -1858,7 +1858,7 @@ class TestCF1_7(BaseTestCase):
         dataset = self.load_dataset(STATIC_FILES["grid-boundaries"])
         results = self.cf.check_cell_boundaries(dataset)
         score, out_of, messages = get_results(results)
-        assert (score, out_of) == (2, 2)
+        assert (score, out_of) == (0, 2)
 
         dataset = self.load_dataset(STATIC_FILES["cf_example_cell_measures"])
         results = self.cf.check_cell_boundaries(dataset)

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -1896,6 +1896,38 @@ class TestCF1_7(BaseTestCase):
                 in messages
             )
 
+    def test_check_cell_boundaries_interval(self):
+        '''
+        7.1 Cell Boundaries
+        Recommendations: (1/2)
+        The points specified by a coordinate or auxiliary coordinate variable 
+        should lie within, or on the boundary, of the cells specified by the 
+        associated boundary variable.
+        ''' 
+
+        # create Cells on a longitude axis
+        dataset = MockTimeSeries()
+        dataset.createDimension("rnv", 2)
+        dataset.createDimension("rlon", 2)
+        dataset.createVariable("rlon", "d", ("rlon",))
+        dataset.createVariable("rlon_bnds", "d", ("rlon", "rnv"))
+        
+        rlon = dataset.variables["rlon"]
+        rlon.standard_name = 'longitude'
+        rlon.units = 'degrees_east'
+        rlon.axis = 'X'  
+        rlon.long_name = 'Longitude'
+        rlon.bounds = 'rlon_bnds'
+        rlon[:] = np.array([-97.5, -99.5], dtype=np.float64)
+
+        rlon_bnds = dataset.variables["rlon_bnds"]
+        rlon_bnds.long_name = 'Longitude Cell Boundaries'
+        rlon_bnds[:] = np.array([[-97, -98], [-98, -99]], dtype=np.float64)   
+
+        results = self.cf.check_cell_boundaries_interval(dataset)
+        score, out_of, messages = get_results(results)
+        assert (score, out_of) == (1, 2)             
+                      
     def test_cell_measures(self):
         """Over-ride the test_cell_measures from CF1_6"""
 


### PR DESCRIPTION
This is related to [issue#952] (https://github.com/ioos/compliance-checker/issues/952)

Changed the line to (0, 2) because some of the checks will fail such as the comparison of the attributes values between the boundary_variable and its corresponding variable.